### PR TITLE
fix build warning

### DIFF
--- a/client.c
+++ b/client.c
@@ -37,16 +37,20 @@ int main()
     // Send a stream of bytes in the form of a Request structure.
     // NOTE: The 'if' expression is used to silence the compiler about
     // complaining about an unused result (warn_unused_result).
-    if (write(sockfd, (byte*)&req, sizeof(Request)));
+    if (write(sockfd, (byte*)&req, sizeof(Request)) < 0) {
+      printf("client write fail here\n");
+    }
 
     // Read a stream of bytes in the form of a Response structure.
     // NOTE: The 'if' expression is used to silence the compiler about
     // complaining about an unused result (warn_unused_result).
-    if (read(sockfd, (byte*)&res, sizeof(Response)));
+    if (read(sockfd, (byte*)&res, sizeof(Response)) < 0) {
+      printf("client read fail here\n");
+    }
 
     printResponse(res);
-    
+
     close(sockfd);
-    
+
     return 0;
 }

--- a/server.c
+++ b/server.c
@@ -88,7 +88,9 @@ int main() {
   // from end-user.
   // NOTE: The 'if' expression is used to silence the compiler about
   // complaining about an unused result (warn_unused_result).
-  if (read(comm_fd, (byte*)&req, sizeof(Request)));
+  if (read(comm_fd, (byte*)&req, sizeof(Request)) < 0) {
+    printf("server read fail here\n");
+  }
 
   // Verify that ACK is set properly
   if (req.ack == ACK) {
@@ -112,12 +114,14 @@ int main() {
     // Send a stream of bytes back in the form of a Response structure.
     // NOTE: The 'if' expression is used to silence the compiler about
     // complaining about an unused result (warn_unused_result).
-    if (write(comm_fd, (byte*)&res, sizeof(Response)));
+    if (write(comm_fd, (byte*)&res, sizeof(Response)) < 0) {
+      printf("server write fail here\n");
+    }
   }
   else {
     printf("Unrecognized ACK (%d). Failing here\n", req.ack);
   }
-  
+
   close(comm_fd);
 
   return 0;


### PR DESCRIPTION
gcc    -c -o server.o server.c
gcc    -c -o client.o client.c
client.c:40:53: warning: if statement has empty body [-Wempty-body]
    if (write(sockfd, (byte*)&req, sizeof(Request)));
                                                    ^
client.c:40:53: note: put the semicolon on a separate line to silence this warning
client.c:45:53: warning: if statement has empty body [-Wempty-body]
    if (read(sockfd, (byte*)&res, sizeof(Response)));
                                                    ^
client.c:45:53: note: put the semicolon on a separate line to silence this warning
2 warnings generated.
server.c:91:51: warning: if statement has empty body [-Wempty-body]
  if (read(comm_fd, (byte*)&req, sizeof(Request)));
                                                  ^
server.c:91:51: note: put the semicolon on a separate line to silence this warning
server.c:115:55: warning: if statement has empty body [-Wempty-body]
    if (write(comm_fd, (byte*)&res, sizeof(Response)));
                                                      ^
server.c:115:55: note: put the semicolon on a separate line to silence this warning

Signed-off-by: Junbo Zheng <3273070@qq.com>